### PR TITLE
Fix check in a nested directory on GitHub

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "deno.enable": true,
+  "deno.enable": true
 }

--- a/site/docs/id/test.md
+++ b/site/docs/id/test.md
@@ -1,0 +1,2 @@
+[holla](https://github.com/grammyjs/auto-retry/blob/main/src/index.ts)
+[yes](https://github.com/grammyjs/examples/tree/main/scaling)

--- a/site/docs/id/test.md
+++ b/site/docs/id/test.md
@@ -1,2 +1,0 @@
-[holla](https://github.com/grammyjs/auto-retry/blob/main/src/index.ts)
-[yes](https://github.com/grammyjs/examples/tree/main/scaling)

--- a/utilities.ts
+++ b/utilities.ts
@@ -52,13 +52,14 @@ export function transformURL(url: string) {
      * into this:
      * ["https://github.com/", "grammyjs/website/", "tree/", "main/site/docs/, "advanced", "foo"]
      */
-    const re =
-      /^.*\.com\/([^\/]+\/[^\/]+\/)(?:tree\/|blob\/)(.*\/)([^\/#]+)#?(.*)?$/;
+    const re = /^.*\.com\/([^\/]+\/[^\/]+\/)(?:tree\/)(.*\/)([^\/#]+)#?(.*)?$/;
     const match = url.match(re);
 
-    // If url does not contain "tree" or "blob" (means not nested directory), then parse them as the regular external link.
     if (match) {
       let [, repo, path, fileName, anchor] = match;
+
+      if (anchor === undefined) return url;
+
       if (!fileName.endsWith(".md")) {
         fileName += "/README.md";
       }


### PR DESCRIPTION
Please try opening this link, https://github.com/grammyjs/storages/tree/main/packages#grammy-storages, without JavaScript.
The link checker will not be able to find the anchor because the DOM is not fully rendered.