### PR TITLE
feat: Group related output

### DIFF
--- a/deps/std/assert.ts
+++ b/deps/std/assert.ts
@@ -1,2 +1,3 @@
 export { assert } from "https://deno.land/std@0.214.0/assert/assert.ts";
 export { assertFalse } from "https://deno.land/std@0.214.0/assert/assert_false.ts";
+export { equal } from "https://deno.land/std@0.214.0/assert/equal.ts";

--- a/deps/std/fmt.ts
+++ b/deps/std/fmt.ts
@@ -1,1 +1,12 @@
-export { blue, bold, cyan, dim, green, magenta, red, yellow } from "https://deno.land/std@0.214.0/fmt/colors.ts";
+export {
+  blue,
+  bold,
+  cyan,
+  dim,
+  green,
+  magenta,
+  red,
+  strikethrough,
+  underline,
+  yellow,
+} from "https://deno.land/std@0.214.0/fmt/colors.ts";

--- a/deps/std/path.ts
+++ b/deps/std/path.ts
@@ -1,2 +1,3 @@
 export { extname } from "https://deno.land/std@0.214.0/path/extname.ts";
+export { resolve } from "https://deno.land/std@0.214.0/path/resolve.ts";
 export { join } from "https://deno.land/std@0.214.0/path/join.ts";

--- a/issues.ts
+++ b/issues.ts
@@ -1,8 +1,8 @@
-import { blue, cyan, dim, magenta, red, yellow } from "./deps/std/fmt.ts";
-
+import { bold, cyan, dim, green, red, strikethrough, underline, yellow } from "./deps/std/fmt.ts";
 import { Issue } from "./types.ts";
-
-const LIST_BULLET = "—";
+import { parseLink } from "./utilities.ts";
+import { extname, resolve } from "./deps/std/path.ts";
+import { equal } from "./deps/std/assert.ts";
 
 export const ISSUE_TITLES: Record<Issue["type"], string> = {
   empty_dom: "Empty DOM content",
@@ -17,90 +17,192 @@ export const ISSUE_TITLES: Record<Issue["type"], string> = {
   linked_file_not_found: "Missing files",
 };
 
-const MAX_TITLE_LENGTH = Object.values(ISSUE_TITLES)
-  .reduce((prevLength, title) => title.length > prevLength ? title.length : prevLength, 0) + 1;
+const ISSUE_DESCRIPTIONS: Record<Issue["type"], string> = {
+  "unknown_link_format": `\
+The links highlighted in red seems to be an invalid type of link. Please check the source
+files and correct the hyperlinks involved. If you think this was a mistake, please open
+an issue over about this here: https://github.com/grammyjs/link-checker/issues/new.`,
+  "empty_dom": `\
+The HTML document returned by the request couldn't be parsed properly by the HTML parser used.
+Either the request returned nothing, or it was an invalid type of content. This issue must be
+investigated and the links should be updated accordingly.`,
+  "not_ok_response": `\
+The following highlighted links returned documents with non-OK response status codes.
+The corresponding non-OK status codes are provided with them.`,
+  "wrong_extension": `\
+Local relative links to another file shouldn't be ending with an extension as configured.
+All links that doesn't follow this strict limit is listed below.`,
+  "linked_file_not_found": `The files linked do not exist at the given paths.`,
+  "redirected": `The links were redirected to a newer page or some other page according to the responses.`,
+  "missing_anchor": `Some links were pinned with an anchor. But the linked document doesn't have such an anchor.`,
+  "empty_anchor": `Restricts linking pages with no anchor destination. In other words, just '#'.`,
+  "no_response": `\
+The following links does not return any response (probably timed out). This could be a
+network issue, an internal server issue, or the page doesn't exist at all for some reason.`,
+  "disallow_extension": `\
+Some local files seems to be linked with a prohibited extension. This should be changed
+to the correct extension.`,
+};
 
-export function makeIssueMessage(issue: Issue) {
+function makePrettyDetails(issue: Issue) {
+  if ("reference" in issue) issue.reference = decodeURI(issue.reference);
+  if ("to" in issue) issue.to = decodeURI(issue.to), issue.from = decodeURI(issue.from);
+
   switch (issue.type) {
     case "unknown_link_format":
-      return `The link ${cyan(decodeURI(issue.reference))} seems to be a unknown type of link.\n` +
-        yellow("Please open an issue about this here: https://github.com/grammyjs/link-checker/issues/new.");
+      return `${underline(red(issue.reference))}`;
     case "empty_dom":
-      return `The document at ${cyan(decodeURI(issue.reference))} can't seem to be properly parsed.`;
+      return `${underline(red(issue.reference))}`;
     case "not_ok_response":
-      return `The link ${cyan(issue.reference)} responded with a not OK status code ${red(`${issue.status}`)}.` +
-        (issue.statusText ? ` It says "${issue.statusText}"` : "");
-    case "wrong_extension":
-      return `${cyan(decodeURI(issue.reference))} is ending with the extension ${yellow(issue.actual)} instead of ${
-        yellow(issue.expected)
-      }.`;
+      return `[${red(issue.status.toString())}] ${underline(issue.reference)}`; // TODO: show issue.statusText
+    case "wrong_extension": {
+      const { root, anchor } = parseLink(issue.reference);
+      return `${root.slice(0, -extname(root).length)}\
+${bold(`${strikethrough(red(issue.actual))}${green(issue.expected)}`)}\
+${anchor ? dim("#" + anchor) : ""}`;
+    }
     case "linked_file_not_found":
-      return `The linked file ${magenta(issue.filepath)} does not exist.`;
+      return `${dim(red(issue.filepath))} (not found)`;
     case "redirected":
-      return `The link ${cyan(decodeURI(issue.from))} was redirected to ${cyan(decodeURI(issue.to))}.`;
+      return `${underline(yellow(issue.from))} --> ${underline(green(issue.to))}`;
     case "missing_anchor":
-      return `The webpage at ${cyan(decodeURI(issue.reference))} doesn't seem to be have the anchor ${
-        blue(decodeURI(issue.anchor))
-      }`;
+      return `${underline(issue.reference)}${red(bold("#" + issue.anchor))}`;
     case "empty_anchor":
-      return `The page ${cyan(decodeURI(issue.reference))} seems to be linked with an empty anchor.`;
+      return `${underline(issue.reference)}${red(bold("#"))}`;
     case "no_response":
-      return `There was no response from ${cyan(decodeURI(issue.reference))}.`;
-    case "disallow_extension":
-      return `The ${yellow(issue.extension)} extension is disallowed at here: ${magenta(decodeURI(issue.reference))}.`;
+      return `${underline(issue.reference)}`;
+    case "disallow_extension": {
+      const { root, anchor } = parseLink(issue.reference);
+      return `${root.slice(0, -extname(root).length)}\
+${bold(strikethrough(red(issue.extension)))}${anchor ? dim("#" + anchor) : ""}`;
+    }
     default:
       throw new Error("Invalid type of issue! This shouldn't be happening.");
   }
 }
 
-export function prettySummary(issues: Record<string, Issue[]>) {
-  const counts: Record<Issue["type"], number> = {
-    empty_dom: 0,
-    redirected: 0,
-    no_response: 0,
-    empty_anchor: 0,
-    missing_anchor: 0,
-    not_ok_response: 0,
-    wrong_extension: 0,
-    disallow_extension: 0,
-    unknown_link_format: 0,
-    linked_file_not_found: 0,
-  };
-
-  for (const filepath in issues) {
-    for (const issue of issues[filepath]) {
-      counts[issue.type]++;
-    }
-  }
-
-  const totalIssues = Object.values(counts).reduce((p, c) => p + c, 0);
-  const maxCountLength = totalIssues.toString().length;
-
-  let summary = "";
-  for (const type_ in counts) {
-    const type = type_ as Issue["type"];
-    if (counts[type] === 0) continue;
-    const title = ISSUE_TITLES[type].padStart(MAX_TITLE_LENGTH, " ");
-    const count = counts[type].toString().padStart(maxCountLength, " ");
-    summary += `│ ${title} │ ${count} │\n`;
-  }
-
-  const maxLineLength = summary.split("\n").reduce((p, c) => c.length > p ? c.length : p, 0);
-
-  if (totalIssues > 0) {
-    return {
-      totalIssues,
-      summary: `┌${"─".repeat(maxLineLength - maxCountLength - 5)}┬${"─".repeat(maxCountLength + 2)}┐\n` +
-        `${summary}` +
-        `├${"─".repeat(MAX_TITLE_LENGTH + 2)}┼${"─".repeat(maxCountLength + 2)}┤\n` +
-        `│ ${"Total".padStart(MAX_TITLE_LENGTH, " ")} │ ${totalIssues} │\n` +
-        `└${"─".repeat(MAX_TITLE_LENGTH + 2)}┴${"─".repeat(maxCountLength + 2)}┘`,
-    };
-  } else {
-    return { totalIssues, summary: "" };
+function getSearchString(issue: Issue) {
+  switch (issue.type) {
+    case "redirected":
+      return `${issue.from}`;
+    case "not_ok_response":
+      return `${issue.reference}`;
+    case "no_response":
+      return `${issue.reference}`;
+    case "missing_anchor":
+      return `${issue.reference}#${issue.anchor}`;
+    case "empty_dom":
+      return `${issue.reference}`;
+    case "disallow_extension":
+      return `${issue.reference}`;
+    case "wrong_extension":
+      return `${issue.reference}`;
+    case "linked_file_not_found":
+      return `${issue.filepath}`;
+    case "unknown_link_format":
+      return `${issue.reference}`;
+    case "empty_anchor":
+      return `${issue.reference}`;
   }
 }
 
-export function generateIssueList(issues: Issue[]) {
-  return issues.map((issue) => dim(LIST_BULLET) + " " + makeIssueMessage(issue)).join("\n");
+function getColumns(haystack: string, needle: string) {
+  const indices: number[] = [];
+  while (haystack.includes(needle)) {
+    const length = indices.push(haystack.indexOf(needle) + 1);
+    haystack = haystack.slice(indices[length - 1]);
+  }
+  return indices;
+}
+
+// little grep (my own impl.)
+async function findStringLocations(
+  filepath: string,
+  searchString: string,
+): Promise<[line: number, columns: number[] /*, text: string */][]> {
+  using file = await Deno.open(filepath, { read: true });
+  let tempLine = "";
+  let currentLine = 1;
+  const locations: [line: number, columns: number[] /*, text: string */][] = [];
+  const decoder = new TextDecoder();
+  for await (const chunk of file.readable) {
+    const decodedChunk = decoder.decode(chunk);
+    const lines = decodedChunk.split("\n");
+    tempLine += lines.shift();
+    if (lines.length <= 1) continue;
+    if (tempLine.includes(searchString)) {
+      locations.push([currentLine, getColumns(tempLine, searchString) /*, tempLine */]);
+    }
+    currentLine += 1;
+    tempLine = lines.pop()!;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.includes(searchString)) {
+        locations.push([currentLine, getColumns(line, searchString) /*, line */]);
+      }
+      currentLine += 1;
+    }
+  }
+  return locations;
+}
+
+async function generateStackTrace(filepaths: string[], searchString: string) {
+  return (await Promise.all(
+    filepaths.sort((a, b) => a.localeCompare(b)).map(async (filepath) => {
+      const locations = await findStringLocations(filepath, searchString);
+      if (locations.length == 0) {
+        console.error(yellow(`\
+====================================================================================
+PANIK. This shouldn't be happening. The search strings are supposed to have at least
+one occurrence in the corresponding file. Please report this issue with enough
+information and context at: https://github.com/grammyjs/link-checker/issues/new.
+====================================================================================`));
+        return [];
+      }
+      return locations.map(([lineNumber, columns]) =>
+        columns.map((column) => `at ${cyan(resolve(filepath))}:${yellow(lineNumber.toString())}:${yellow(column.toString())}`)
+      ).flat();
+    }),
+  )).flat().join("\n");
+}
+
+function indentText(text: string, indentSize: number) {
+  const indent = " ".repeat(indentSize);
+  return text.includes("\n") ? text.split("\n").map((line) => indent + line).join("\n") : indent + text;
+}
+
+export async function generateReport(issues: Record<string, Issue[]>) {
+  if (Object.keys(issues).length === 0) {
+    return { total: 0, report: green("Found no issues with links in the documentation!") };
+  }
+  const grouped = Object.entries(issues).map(([filepath, issues]) => {
+    return issues.map((issue) => ({ filepath, issue }));
+  }).flat().reduce((deduped, current) => {
+    const alreadyDeduped = deduped.find((x) => equal(current.issue, x.details));
+    if (alreadyDeduped == null) return deduped.concat({ details: current.issue, stack: [current.filepath] });
+    alreadyDeduped.stack.push(current.filepath);
+    return deduped;
+  }, [] as { details: Issue; stack: string[] }[]).reduce((grouped, issue) => {
+    grouped[issue.details.type] ??= [];
+    grouped[issue.details.type].push(issue);
+    return grouped;
+  }, {} as Record<Issue["type"], { details: Issue; stack: string[] }[]>);
+
+  let report = "", total = 0;
+  const issueTypes = Object.keys(grouped) as Issue["type"][];
+  for (const type of issueTypes) {
+    const title = ISSUE_TITLES[type];
+    report += "\n\n" + bold(title) + " (" + grouped[type].length + ")\n";
+    report += ISSUE_DESCRIPTIONS[type];
+    for (const { details, stack } of grouped[type]) {
+      report += "\n\n";
+      report += indentText(makePrettyDetails(details), 1);
+      const stackTrace = await generateStackTrace(stack, getSearchString(details));
+      report += "\n" + indentText(stackTrace, 4);
+    }
+    report += "\n";
+    total += grouped[type].length;
+  }
+
+  return { total, report: red(bold(`Found ${total} issues in the documentation:`)) + report + "Checking completed." };
 }

--- a/issues.ts
+++ b/issues.ts
@@ -192,7 +192,7 @@ export async function generateReport(issues: Record<string, Issue[]>) {
   const issueTypes = Object.keys(grouped) as Issue["type"][];
   for (const type of issueTypes) {
     const title = ISSUE_TITLES[type];
-    report += "\n\n" + bold(title) + " (" + grouped[type].length + ")\n";
+    report += "\n" + bold(title) + " (" + grouped[type].length + ")\n";
     report += ISSUE_DESCRIPTIONS[type];
     for (const { details, stack } of grouped[type]) {
       report += "\n\n";
@@ -204,5 +204,9 @@ export async function generateReport(issues: Record<string, Issue[]>) {
     total += grouped[type].length;
   }
 
-  return { total, report: red(bold(`Found ${total} issues in the documentation:`)) + report + "Checking completed." };
+  return {
+    total,
+    report: "\n" + red(bold(`Found ${total} issues across the documentation:`)) + "\n" + report +
+      `\nChecking completed and found ${bold(total.toString())} issues.`,
+  };
 }

--- a/issues.ts
+++ b/issues.ts
@@ -41,7 +41,7 @@ The following links does not return any response (probably timed out). This coul
 network issue, an internal server issue, or the page doesn't exist at all for some reason.`,
   "disallow_extension": `\
 Some local files seems to be linked with extension, and the use of extensions while linking
-local documents are prohibited. Remove them.`,
+local documents is prohibited. Remove the following extensions.`,
 };
 
 function makePrettyDetails(issue: Issue) {

--- a/issues.ts
+++ b/issues.ts
@@ -40,8 +40,8 @@ All links that doesn't follow this strict limit is listed below.`,
 The following links does not return any response (probably timed out). This could be a
 network issue, an internal server issue, or the page doesn't exist at all for some reason.`,
   "disallow_extension": `\
-Some local files seems to be linked with a prohibited extension. This should be changed
-to the correct extension.`,
+Some local files seems to be linked with extension, and the use of extensions while linking
+local documents are prohibited. Remove them.`,
 };
 
 function makePrettyDetails(issue: Issue) {

--- a/types.ts
+++ b/types.ts
@@ -4,7 +4,21 @@ type MarkdownItToken = ReturnType<
   InstanceType<typeof MarkdownIt>["parse"]
 >[number];
 
+export const ISSUE_TYPES = [
+  "unknown_link_format",
+  "empty_dom",
+  "empty_anchor",
+  "no_response",
+  "not_ok_response",
+  "disallow_extension",
+  "wrong_extension",
+  "linked_file_not_found",
+  "redirected",
+  "missing_anchor",
+] as const;
+
 interface BaseIssue {
+  type: typeof ISSUE_TYPES[number];
   reference: string;
 }
 interface UnknownLinkFormatIssue extends BaseIssue {

--- a/website.ts
+++ b/website.ts
@@ -3,7 +3,7 @@ import { anchorPlugin } from "./deps/markdown-it/anchor.ts";
 import { MarkdownIt } from "./deps/markdown-it/mod.ts";
 import { slugifyPlugin } from "./deps/markdown-it/slugify.ts";
 import { extname, join } from "./deps/std/path.ts";
-import { blue, magenta } from "./deps/std/fmt.ts";
+import { blue, dim, magenta } from "./deps/std/fmt.ts";
 
 import { isValidAnchor, transformURL } from "./fetch.ts";
 import { Issue, MissingAnchorIssue } from "./types.ts";
@@ -53,7 +53,7 @@ export async function readMarkdownFiles(
       }
 
       if (extname(entry.name) !== ".md") continue;
-      console.log(magenta("reading"), filepath);
+      console.log(dim(`${magenta("reading")} ${filepath}`));
 
       const parsed = await parseMarkdownFile(filepath);
 

--- a/website_cli.ts
+++ b/website_cli.ts
@@ -1,7 +1,5 @@
 import { parseArgs } from "./deps/std/cli.ts";
-import { bold, green, red } from "./deps/std/fmt.ts";
-
-import { generateIssueList, prettySummary } from "./issues.ts";
+import { generateReport } from "./issues.ts";
 import { readMarkdownFiles } from "./website.ts";
 
 const args = parseArgs(Deno.args, {
@@ -27,19 +25,7 @@ const issues = await readMarkdownFiles(ROOT_DIRECTORY, {
   allowHtmlExtension: args["allow-ext-html"],
 });
 
-const { totalIssues, summary } = prettySummary(issues);
-
-if (totalIssues === 0) {
-  console.log(green("You're good to go! No issues were found!"));
-  Deno.exit(0);
-}
-
-console.log(red(`Found ${totalIssues} issues in the documentation:\n`));
-console.log(summary);
-
-for (const filepath of Object.keys(issues).sort((a, b) => a.localeCompare(b))) {
-  console.log("\n" + bold(filepath), `(${issues[filepath].length})`);
-  console.log(generateIssueList(issues[filepath]));
-}
+const { report } = await generateReport(issues);
+console.log(report);
 
 Deno.exit(1);


### PR DESCRIPTION
Closes #12 

Bugs are expected because this ain't tested very well.

Also this PQ fixes some issues with grouped GitHub links.

Output obtained when running documentation link checker on grammyjs/website at the time of writing this.

![image](https://github.com/grammyjs/link-checker/assets/70066170/07d29ee5-0115-4c59-a225-0ad910c89a3d)
